### PR TITLE
Fix missing collaborator logos in production

### DIFF
--- a/src/app/colaboradores/page.tsx
+++ b/src/app/colaboradores/page.tsx
@@ -21,14 +21,14 @@ const colaboradores = [
   },
   {
     name: "Coordinar",
-    src: "/coordinar.webp",
+    src: "/Coordinar.webp",
     alt: "Logo de Coordinar",
     width: 180,
     height: 90,
   },
   {
     name: "Argenpesos",
-    src: "/argenpesos.webp",
+    src: "/Argenpesos.webp",
     alt: "Logo de Argenpesos",
     width: 190,
     height: 90,


### PR DESCRIPTION
### Motivation
- Production runs on a case-sensitive filesystem so logos for `Coordinar` and `Argenpesos` failed to load due to mismatched filename casing, causing missing images on the Colaboradores page.

### Description
- Updated `src/app/colaboradores/page.tsx` to change the `src` entries for those collaborators to `"/Coordinar.webp"` and `"/Argenpesos.webp"` so they match the actual files in `public/`.

### Testing
- Ran `npm run lint` which completed successfully and reported only preexisting unrelated warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8ea4edcc8321b33906442c3d554a)