### PR TITLE
Add María chat UI, lead evaluation utils and Google Sheets leads API

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "next-sitemap": "^4.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "swiper": "^12.0.3"
+    "swiper": "^12.0.3",
+    "googleapis": "^144.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -1,0 +1,58 @@
+import { google } from "googleapis";
+import { NextResponse } from "next/server";
+
+type LeadData = {
+  fecha: string;
+  nombreApellido: string;
+  sexo: "F" | "M";
+  dni: string;
+  cuil: string;
+  actividad: string;
+  subActividad?: string;
+  situacionBcra: string;
+  banco: string;
+  whatsapp?: string;
+  resultado: string;
+};
+
+const requiredFields: Array<keyof Pick<LeadData, "fecha" | "dni" | "cuil" | "actividad" | "banco" | "resultado">> = ["fecha", "dni", "cuil", "actividad", "banco", "resultado"];
+
+const getMissingFields = (lead: LeadData): string[] => requiredFields.filter((field) => !lead[field] || String(lead[field]).trim() === "");
+
+export async function POST(request: Request) {
+  try {
+    const lead = (await request.json()) as LeadData;
+    const missingFields = getMissingFields(lead);
+    if (missingFields.length > 0) {
+      return NextResponse.json({ error: `Faltan campos obligatorios: ${missingFields.join(", ")}` }, { status: 400 });
+    }
+
+    const sheetId = process.env.GOOGLE_SHEET_ID;
+    const clientEmail = process.env.GOOGLE_CLIENT_EMAIL;
+    const privateKey = process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+    if (!sheetId || !clientEmail || !privateKey) {
+      return NextResponse.json({ error: "Faltan variables de entorno para Google Sheets." }, { status: 500 });
+    }
+
+    const auth = new google.auth.JWT({ email: clientEmail, key: privateKey, scopes: ["https://www.googleapis.com/auth/spreadsheets"] });
+    const sheets = google.sheets({ version: "v4", auth });
+
+    // TODO: Integrar BCRA para completar nombreApellido real.
+    // TODO: Integrar BCRA para calcular situacionBcra real.
+    // TODO: Reemplazar valores mock por respuesta real de BCRA.
+    const row = [lead.fecha, lead.nombreApellido, lead.sexo, lead.dni, lead.cuil, lead.actividad, lead.subActividad || "", lead.situacionBcra, lead.banco, lead.whatsapp || "", lead.resultado];
+
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: sheetId,
+      range: "Sheet1!A:K",
+      valueInputOption: "USER_ENTERED",
+      requestBody: { values: [row] },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error guardando lead en Google Sheets", error);
+    return NextResponse.json({ error: "No se pudo guardar el lead." }, { status: 500 });
+  }
+}

--- a/src/app/test-chat/page.tsx
+++ b/src/app/test-chat/page.tsx
@@ -1,0 +1,12 @@
+import MariaCredizzaChat from "@/components/chat/MariaCredizzaChat";
+
+export default function TestChatPage() {
+  return (
+    <main className="min-h-screen bg-slate-100 p-4">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-4 text-2xl font-bold text-[#004E9B]">Prueba de chat de precalificación</h1>
+        <MariaCredizzaChat />
+      </div>
+    </main>
+  );
+}

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { Actividad, ChatStep, LeadData, Sexo, SubActividad } from "./mariaCredizzaChat.types";
+import {
+  ACTIVIDADES_DISPONIBLES,
+  BANCOS_DISPONIBLES,
+  buildLeadData,
+  buildWhatsAppMessage,
+  evaluateLead,
+  generateCuil,
+  getSubactivityPrompt,
+  mockBcraData,
+  normalizeDni,
+  nowAsDisplayDate,
+  saveLeadMock,
+  toVisibleResult,
+  validateDni,
+} from "./mariaCredizzaChat.utils";
+
+type ChatMessage = { from: "bot" | "user"; text: string };
+
+const INITIAL_BOT_MESSAGE = "Hola 👋 Soy María de Credizza. Vamos a iniciar su evaluación para obtener un crédito. Es rápido y sin compromiso.";
+const CREDIZZA_WHATSAPP = "5491166669143";
+
+const ACTIVIDAD_SUBOPCIONES: Partial<Record<Actividad, readonly SubActividad[]>> = {
+  Jubilado: ["ANSES", "IPS Bs.As.", "Provincial Santa Fe", "Provincial Chubut", "Otro"],
+  "Pensión por viudez": ["ANSES", "IPS Bs.As.", "Provincial Santa Fe", "Provincial Chubut", "Otro"],
+  Docente: ["Pública", "Privada"],
+  Policía: ["Provincia Bs.As.", "CABA", "Provincial Santa Fe", "Provincial Chubut", "Otro"],
+  Pensiones: ["PUAM", "PNC", "MADRES", "Otro"],
+  "Empleado público": ["Nacional", "Provincial", "Municipal"],
+};
+
+const SUBOPCIONES_NIVEL_2: Partial<Record<SubActividad, readonly SubActividad[]>> = {
+  Pública: ["Provincia Bs.As.", "CABA", "Provincial Santa Fe", "Provincial Chubut", "Otro"],
+  Provincial: ["Provincia Bs.As.", "CABA", "Provincial Santa Fe", "Provincial Chubut", "Otro"],
+};
+
+const suggestedBankForSub = (value: SubActividad | null, actividad: Actividad | null): string | null => {
+  if (actividad === "Empleado GCBA") return "Ciudad de Bs.As.";
+  if (actividad === "Empleado provincial de Santa Fe") return "Nuevo Banco Santa Fe";
+  if (actividad === "Empleado provincial Chubut") return "Banco Chubut";
+
+  const map: Partial<Record<SubActividad, string>> = {
+    "IPS Bs.As.": "Provincia Bs.As.",
+    "Provincia Bs.As.": "Provincia Bs.As.",
+    CABA: "Ciudad de Bs.As.",
+    "Provincial Santa Fe": "Nuevo Banco Santa Fe",
+    "Provincial Chubut": "Banco Chubut",
+    Nacional: "Nación",
+  };
+  return value ? map[value] ?? null : null;
+};
+
+const INITIAL_LEAD: LeadData = buildLeadData({});
+
+export default function MariaCredizzaChat() {
+  const [step, setStep] = useState<ChatStep>("inicio");
+  const [messages, setMessages] = useState<ChatMessage[]>([{ from: "bot", text: INITIAL_BOT_MESSAGE }]);
+  const [lead, setLead] = useState<LeadData>(INITIAL_LEAD);
+  const [actividadInput, setActividadInput] = useState("");
+  const [subOptions, setSubOptions] = useState<readonly SubActividad[]>([]);
+  const [secondSubOptions, setSecondSubOptions] = useState<readonly SubActividad[]>([]);
+  const [bancoInput, setBancoInput] = useState("");
+  const [suggestedBank, setSuggestedBank] = useState<string | null>(null);
+  const [showFullBankSearch, setShowFullBankSearch] = useState(true);
+  const [dniInput, setDniInput] = useState("");
+  const [dniError, setDniError] = useState("");
+  const [whatsInput, setWhatsInput] = useState("");
+  const [whatsError, setWhatsError] = useState("");
+  const [shouldOpenCredizzaWhatsapp, setShouldOpenCredizzaWhatsapp] = useState(false);
+
+  const chatEndRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [step, messages]);
+
+  const actividadFiltrada = useMemo(() => ACTIVIDADES_DISPONIBLES.filter((item) => item.toLowerCase().includes(actividadInput.toLowerCase())), [actividadInput]);
+  const bancosFiltrados = useMemo(() => BANCOS_DISPONIBLES.filter((item) => item.toLowerCase().includes(bancoInput.toLowerCase())), [bancoInput]);
+
+  const addBot = (text: string): void => setMessages((prev) => [...prev, { from: "bot", text }]);
+  const addUser = (text: string): void => setMessages((prev) => [...prev, { from: "user", text }]);
+
+  const resetChat = (): void => {
+    setStep("inicio");
+    setMessages([{ from: "bot", text: INITIAL_BOT_MESSAGE }]);
+    setLead(buildLeadData({ fecha: nowAsDisplayDate() }));
+    setActividadInput("");
+    setSubOptions([]);
+    setSecondSubOptions([]);
+    setBancoInput("");
+    setSuggestedBank(null);
+    setShowFullBankSearch(true);
+    setDniInput("");
+    setDniError("");
+    setWhatsInput("");
+    setWhatsError("");
+    setShouldOpenCredizzaWhatsapp(false);
+  };
+
+  const goToBankStep = (actividad: Actividad, subActividad: SubActividad | null): void => {
+    const suggested = suggestedBankForSub(subActividad, actividad);
+    setSuggestedBank(suggested);
+    setShowFullBankSearch(!suggested);
+    addBot("Indique su banco.");
+    setStep("banco");
+  };
+
+  const onBack = (): void => {
+    if (step === "subActividad") {
+      setStep("actividad");
+      setLead((prev) => ({ ...prev, subActividad: "", banco: "", dni: "", cuil: "", sexo: "", resultado: "", whatsapp: "" }));
+      setSecondSubOptions([]);
+      return;
+    }
+    if (step === "banco") {
+      const hasSub = Boolean(lead.subActividad) || subOptions.length > 0 || secondSubOptions.length > 0;
+      setStep(hasSub ? "subActividad" : "actividad");
+      setLead((prev) => ({ ...prev, banco: "", dni: "", cuil: "", sexo: "", resultado: "", whatsapp: "" }));
+      setBancoInput("");
+      return;
+    }
+    if (step === "dni") {
+      setStep("banco");
+      setLead((prev) => ({ ...prev, dni: "", cuil: "", sexo: "", resultado: "", whatsapp: "" }));
+      setDniInput("");
+      setDniError("");
+      return;
+    }
+    if (step === "sexo") {
+      setStep("dni");
+      setLead((prev) => ({ ...prev, sexo: "", cuil: "", resultado: "", whatsapp: "" }));
+    }
+  };
+
+  const showBackButton = step === "subActividad" || step === "banco" || step === "dni" || step === "sexo";
+
+  const onActividad = (actividad: Actividad): void => {
+    addUser(actividad);
+    setActividadInput("");
+    setLead((prev) => ({ ...prev, actividad, subActividad: "" }));
+
+    if (actividad === "Empleado GCBA" || actividad === "Empleado provincial de Santa Fe" || actividad === "Empleado provincial Chubut" || actividad === "No estoy seguro / Otro" || actividad === "AUH") {
+      goToBankStep(actividad, null);
+      return;
+    }
+
+    const initialSub = ACTIVIDAD_SUBOPCIONES[actividad] ?? [];
+    setSubOptions(initialSub);
+    setSecondSubOptions([]);
+    addBot(getSubactivityPrompt(actividad));
+    if (actividad === "Docente") addBot("¿La institución es pública o privada?");
+    if (actividad === "Empleado público") addBot("¿A qué sector pertenece?");
+    setStep("subActividad");
+  };
+
+  const onSubActivity = (value: SubActividad): void => {
+    addUser(value);
+    const nextLevel = SUBOPCIONES_NIVEL_2[value];
+    if (nextLevel) {
+      setLead((prev) => ({ ...prev, subActividad: value }));
+      setSecondSubOptions(nextLevel);
+      addBot("Indique la jurisdicción.");
+      return;
+    }
+
+    setLead((prev) => ({ ...prev, subActividad: value }));
+    const actividadActual: Actividad = lead.actividad || "No estoy seguro / Otro";
+    goToBankStep(actividadActual, value);
+  };
+
+  const onBanco = (banco: string): void => {
+    addUser(banco);
+    setLead((prev) => ({ ...prev, banco }));
+    addBot("Ingrese su DNI.");
+    setStep("dni");
+  };
+
+  const onDni = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const check = validateDni(dniInput);
+    if (!check.isValid) {
+      setDniError(check.error ?? "DNI inválido.");
+      return;
+    }
+    setDniError("");
+    const normalized = normalizeDni(check.normalized);
+    addUser(normalized);
+    setLead((prev) => ({ ...prev, dni: normalized }));
+    addBot("Sexo");
+    setStep("sexo");
+  };
+
+  const onSexo = async (sexo: Sexo): Promise<void> => {
+    addUser(sexo);
+    const cuil = lead.dni ? generateCuil(lead.dni, sexo) : "";
+    const updatedLead: LeadData = buildLeadData({ ...lead, sexo, cuil, fecha: nowAsDisplayDate() });
+    addBot("Procesando información...");
+    setStep("procesando");
+
+    const resultado = evaluateLead(updatedLead, mockBcraData);
+    const finalLead: LeadData = buildLeadData({ ...updatedLead, resultado: toVisibleResult(resultado) });
+    setLead(finalLead);
+    addBot(`Resultado: ${toVisibleResult(resultado)}`);
+    if (resultado === "precalifica_haberes") {
+      addBot("Para continuar con la evaluación por descuento de haberes, será necesario contar con el último recibo de haberes. Un asesor se lo solicitará por WhatsApp.");
+    }
+    addBot("¿Desea continuar por WhatsApp?");
+    setStep("whatsapp");
+  };
+
+  const onWhatsappChoice = (yes: boolean): void => {
+    addUser(yes ? "Sí" : "No");
+    setShouldOpenCredizzaWhatsapp(yes);
+    addBot(
+      yes
+        ? "Indique su número de WhatsApp para que un asesor pueda continuar la gestión."
+        : "Para que un asesor pueda continuar luego con su evaluación, indique su número de WhatsApp.",
+    );
+    setStep("fin");
+  };
+
+  const onManualWhatsapp = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    const cleaned = whatsInput.replace(/\D/g, "");
+    if (cleaned.length < 8) {
+      setWhatsError("Ingrese un número de WhatsApp válido.");
+      return;
+    }
+
+    setWhatsError("");
+    const updated: LeadData = buildLeadData({ ...lead, whatsapp: cleaned });
+    setLead(updated);
+    await saveLeadMock(updated);
+    addUser(cleaned);
+
+    if (shouldOpenCredizzaWhatsapp) {
+      const encodedMessage = buildWhatsAppMessage(updated);
+      window.open(`https://wa.me/${CREDIZZA_WHATSAPP}?text=${encodedMessage}`, "_blank", "noopener,noreferrer");
+      addBot("Perfecto. Un asesor le responderá a la brevedad vía WhatsApp.");
+    } else {
+      addBot("Gracias por completar la precalificación. Un asesor podrá contactarle a la brevedad.");
+    }
+
+    setWhatsInput("");
+    setShouldOpenCredizzaWhatsapp(false);
+  };
+
+  return (
+    <section className="mx-auto w-full max-w-md rounded-2xl border border-sistema-uno bg-background-secondary p-4 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-heading2 text-texto-principal">Asistente María - Credizza</h2>
+        <button type="button" onClick={resetChat} className="text-small text-texto-secundario underline">Reiniciar</button>
+      </div>
+
+      <div className="mb-4 flex max-h-[60vh] flex-col gap-2 overflow-y-auto rounded-xl bg-background-default p-3">
+        {messages.map((m, i) => (
+          <div key={`${m.from}-${i}`} className={`max-w-[90%] rounded-2xl px-3 py-2 text-small ${m.from === "bot" ? "self-start bg-background-secondary text-texto-principal" : "self-end bg-boton-primario text-texto-botones"}`}>
+            {m.text}
+          </div>
+        ))}
+        <div ref={chatEndRef} />
+      </div>
+
+      {(step === "inicio" || step === "actividad") && <div className="space-y-2"><input value={actividadInput} onChange={(e) => setActividadInput(e.target.value)} placeholder="Buscar actividad" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" /><div className="max-h-40 overflow-y-auto rounded-xl border border-sistema-uno">{actividadFiltrada.map((act) => <button key={act} type="button" onClick={() => onActividad(act)} className="block w-full border-b border-sistema-uno px-3 py-2 text-left text-small text-texto-principal">{act}</button>)}</div></div>}
+
+      {step === "subActividad" && <div className="grid grid-cols-1 gap-2">{(secondSubOptions.length > 0 ? secondSubOptions : subOptions).map((item) => <button key={item} type="button" onClick={() => onSubActivity(item)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small text-texto-principal">{item}</button>)}</div>}
+
+      {step === "banco" && <div className="space-y-2">{suggestedBank && !showFullBankSearch ? <div className="grid grid-cols-1 gap-2"><button type="button" onClick={() => onBanco(suggestedBank)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">{suggestedBank}</button><button type="button" onClick={() => setShowFullBankSearch(true)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">Otro banco</button></div> : <><input value={bancoInput} onChange={(e) => setBancoInput(e.target.value)} placeholder="Buscar banco" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" /><div className="max-h-28 overflow-y-auto rounded-xl border border-sistema-uno">{bancosFiltrados.map((bank) => <button key={bank} type="button" onClick={() => onBanco(bank)} className="block w-full border-b border-sistema-uno px-3 py-2 text-left text-small">{bank}</button>)}</div></>}<div className="flex flex-col gap-1"><button type="button" onClick={() => setShowFullBankSearch(true)} className="text-left text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">No encuentro mi banco</button></div></div>}
+
+      {step === "dni" && <form onSubmit={onDni} className="space-y-2"><input value={dniInput} onChange={(e) => setDniInput(e.target.value)} placeholder="Ingrese DNI" inputMode="numeric" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{dniError && <p className="text-smallMobile text-boton-secundario">{dniError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Continuar</button></form>}
+
+      {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
+      {step === "whatsapp" && <div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => onWhatsappChoice(true)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Sí</button><button type="button" onClick={() => onWhatsappChoice(false)} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones">No</button></div>}
+      {step === "fin" && <form onSubmit={(e) => void onManualWhatsapp(e)} className="space-y-2"><input value={whatsInput} onChange={(e) => setWhatsInput(e.target.value)} placeholder="Número de WhatsApp" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{whatsError && <p className="text-smallMobile text-boton-secundario">{whatsError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Guardar número</button></form>}
+
+      {showBackButton && <button type="button" onClick={onBack} className="mt-4 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
+    </section>
+  );
+}

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -67,9 +67,7 @@ export default function MariaCredizzaChat() {
   const [showFullBankSearch, setShowFullBankSearch] = useState(true);
   const [dniInput, setDniInput] = useState("");
   const [dniError, setDniError] = useState("");
-  const [whatsInput, setWhatsInput] = useState("");
-  const [whatsError, setWhatsError] = useState("");
-  const [shouldOpenCredizzaWhatsapp, setShouldOpenCredizzaWhatsapp] = useState(false);
+  const [isRedirectingWhatsapp, setIsRedirectingWhatsapp] = useState(false);
 
   const chatEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -95,9 +93,7 @@ export default function MariaCredizzaChat() {
     setShowFullBankSearch(true);
     setDniInput("");
     setDniError("");
-    setWhatsInput("");
-    setWhatsError("");
-    setShouldOpenCredizzaWhatsapp(false);
+    setIsRedirectingWhatsapp(false);
   };
 
   const goToBankStep = (actividad: Actividad, subActividad: SubActividad | null): void => {
@@ -211,41 +207,30 @@ export default function MariaCredizzaChat() {
     setStep("whatsapp");
   };
 
-  const onWhatsappChoice = (yes: boolean): void => {
+  const onWhatsappChoice = async (yes: boolean): Promise<void> => {
     addUser(yes ? "Sí" : "No");
-    setShouldOpenCredizzaWhatsapp(yes);
-    addBot(
-      yes
-        ? "Indique su número de WhatsApp para que un asesor pueda continuar la gestión."
-        : "Para que un asesor pueda continuar luego con su evaluación, indique su número de WhatsApp.",
-    );
-    setStep("fin");
-  };
 
-  const onManualWhatsapp = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
-    event.preventDefault();
-    const cleaned = whatsInput.replace(/\D/g, "");
-    if (cleaned.length < 8) {
-      setWhatsError("Ingrese un número de WhatsApp válido.");
+    if (yes) {
+      setIsRedirectingWhatsapp(true);
+      addBot("Estamos preparando su atención...");
+
+      const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "Pendiente WhatsApp" });
+      setLead(leadToSave);
+      await saveLeadMock(leadToSave);
+
+      const encodedMessage = buildWhatsAppMessage(leadToSave);
+      window.open(`https://wa.me/${CREDIZZA_WHATSAPP}?text=${encodedMessage}`, "_blank", "noopener,noreferrer");
+      addBot("Perfecto. Un asesor le responderá a la brevedad vía WhatsApp.");
+      setIsRedirectingWhatsapp(false);
+      setStep("fin");
       return;
     }
 
-    setWhatsError("");
-    const updated: LeadData = buildLeadData({ ...lead, whatsapp: cleaned });
-    setLead(updated);
-    await saveLeadMock(updated);
-    addUser(cleaned);
-
-    if (shouldOpenCredizzaWhatsapp) {
-      const encodedMessage = buildWhatsAppMessage(updated);
-      window.open(`https://wa.me/${CREDIZZA_WHATSAPP}?text=${encodedMessage}`, "_blank", "noopener,noreferrer");
-      addBot("Perfecto. Un asesor le responderá a la brevedad vía WhatsApp.");
-    } else {
-      addBot("Gracias por completar la precalificación. Un asesor podrá contactarle a la brevedad.");
-    }
-
-    setWhatsInput("");
-    setShouldOpenCredizzaWhatsapp(false);
+    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "No continuó por WhatsApp" });
+    setLead(leadToSave);
+    await saveLeadMock(leadToSave);
+    addBot("Gracias por completar la precalificación.");
+    setStep("fin");
   };
 
   return (
@@ -274,8 +259,8 @@ export default function MariaCredizzaChat() {
 
       {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
       {step === "whatsapp" && <div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => onWhatsappChoice(true)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Sí</button><button type="button" onClick={() => onWhatsappChoice(false)} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones">No</button></div>}
-      {step === "fin" && <form onSubmit={(e) => void onManualWhatsapp(e)} className="space-y-2"><input value={whatsInput} onChange={(e) => setWhatsInput(e.target.value)} placeholder="Número de WhatsApp" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{whatsError && <p className="text-smallMobile text-boton-secundario">{whatsError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Guardar número</button></form>}
-
+      {isRedirectingWhatsapp && <div className="mt-2 flex items-center gap-2 rounded-xl border border-sistema-uno bg-background-default px-3 py-2 text-small text-texto-principal"><span className="inline-block animate-spin">🪙</span><span>Estamos preparando su atención...</span></div>}
+      
       {showBackButton && <button type="button" onClick={onBack} className="mt-4 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
     </section>
   );

--- a/src/components/chat/mariaCredizzaChat.types.ts
+++ b/src/components/chat/mariaCredizzaChat.types.ts
@@ -1,0 +1,64 @@
+export type ChatStep =
+  | "inicio"
+  | "actividad"
+  | "subActividad"
+  | "banco"
+  | "dni"
+  | "sexo"
+  | "procesando"
+  | "resultado"
+  | "whatsapp"
+  | "fin";
+
+export type Actividad =
+  | "Jubilado"
+  | "Pensión por viudez"
+  | "Docente"
+  | "Policía"
+  | "Pensiones"
+  | "AUH"
+  | "Empleado público"
+  | "Empleado GCBA"
+  | "Empleado provincial de Santa Fe"
+  | "Empleado provincial Chubut"
+  | "No estoy seguro / Otro";
+
+export type SubActividad =
+  | "ANSES"
+  | "IPS Bs.As."
+  | "Provincial Santa Fe"
+  | "Provincial Chubut"
+  | "Otro"
+  | "Pública"
+  | "Privada"
+  | "Provincia Bs.As."
+  | "CABA"
+  | "PUAM"
+  | "PNC"
+  | "MADRES"
+  | "Nacional"
+  | "Provincial"
+  | "Municipal";
+
+export type Sexo = "F" | "M";
+
+export type Resultado =
+  | "precalifica_cbu"
+  | "precalifica_haberes_cbu"
+  | "precalifica_haberes"
+  | "revision_manual"
+  | "rechazado";
+
+export type LeadData = {
+  fecha: string;
+  nombreApellido: string;
+  sexo: Sexo | "";
+  dni: string;
+  cuil: string;
+  actividad: Actividad | "";
+  subActividad: SubActividad | "";
+  situacionBcra: string;
+  banco: string;
+  whatsapp: string;
+  resultado: string;
+};

--- a/src/components/chat/mariaCredizzaChat.utils.ts
+++ b/src/components/chat/mariaCredizzaChat.utils.ts
@@ -1,0 +1,259 @@
+import { Actividad, LeadData, Resultado, Sexo, SubActividad } from "./mariaCredizzaChat.types";
+
+export const ACTIVIDADES_DISPONIBLES: readonly Actividad[] = [
+  "Jubilado",
+  "Pensión por viudez",
+  "Docente",
+  "Policía",
+  "Pensiones",
+  "AUH",
+  "Empleado público",
+  "Empleado GCBA",
+  "Empleado provincial de Santa Fe",
+  "Empleado provincial Chubut",
+  "No estoy seguro / Otro",
+] as const;
+
+export const BANCOS_DISPONIBLES: readonly string[] = [
+  "Galicia",
+  "Nación",
+  "Provincia Bs.As.",
+  "ICBC",
+  "Citibank",
+  "BBVA",
+  "Córdoba",
+  "Supervielle",
+  "Ciudad de Bs.As.",
+  "Patagonia",
+  "Hipotecario",
+  "San Juan",
+  "Santander",
+  "HSBC",
+  "Credicoop",
+  "Itaú",
+  "Macro",
+  "Nuevo Santa Fe",
+  "Chubut",
+  "Santa Cruz",
+  "La Pampa",
+  "Corrientes",
+  "Neuquén",
+  "Valores",
+  "Comafi",
+  "BICE",
+  "Chaco",
+  "Formosa",
+  "CMF",
+  "Santiago del Estero",
+  "Industrial",
+  "Entre Ríos",
+  "Municipal Rosario",
+  "Bank of China",
+  "Brubank",
+  "Bibank",
+  "Open Bank",
+  "JPMorgan",
+  "Roela",
+  "Mariva",
+  "BNP Paribas",
+  "Tierra del Fuego",
+  "BROU",
+  "Sáenz",
+  "Meridian",
+  "Piano",
+  "Julio",
+  "Rioja",
+  "Del Sol",
+  "VOII",
+  "Cetelem",
+  "Servicios Financieros",
+  "Servicios y Transacciones",
+  "RCI",
+  "BACS",
+  "Masventas",
+  "Wilobank",
+  "Columbia",
+  "Bica",
+  "Coinag",
+  "Comercio",
+  "Súcredito",
+  "Dino",
+  "Compañía Financiera Argentina",
+  "Volkswagen Financial",
+  "IUDU",
+  "FCA",
+  "GPAT",
+  "Mercedes-Benz Financiera",
+  "Rombo",
+  "John Deere Credit",
+  "PSA Finance",
+  "Toyota Financiera",
+  "Naranja Digital",
+  "Montemar",
+  "Reba",
+  "Crédito Regional",
+  "Otro banco",
+] as const;
+
+
+export const buildLeadData = (partial: Partial<LeadData>): LeadData => ({
+  fecha: partial.fecha ?? nowAsDisplayDate(),
+  nombreApellido: partial.nombreApellido ?? "",
+  sexo: partial.sexo ?? "",
+  dni: partial.dni ?? "",
+  cuil: partial.cuil ?? "",
+  actividad: partial.actividad ?? "",
+  subActividad: partial.subActividad ?? "",
+  situacionBcra: partial.situacionBcra ?? "Pendiente BCRA",
+  banco: partial.banco ?? "",
+  whatsapp: partial.whatsapp ?? "",
+  resultado: partial.resultado ?? "",
+});
+
+export const normalizeDni = (value: string): string => {
+  const digits = value.replace(/[.\s-]/g, "").replace(/\D/g, "");
+  if (digits.length === 7) return `0${digits}`;
+  return digits;
+};
+
+export const validateDni = (value: string): { isValid: boolean; normalized: string; error?: string } => {
+  const normalized = normalizeDni(value);
+  if (!/^\d+$/.test(normalized)) return { isValid: false, normalized, error: "El DNI debe contener solo números." };
+  if (normalized.length < 8 || normalized.length > 8) {
+    return { isValid: false, normalized, error: "El DNI debe tener 7 u 8 dígitos (se normaliza a 8)." };
+  }
+  return { isValid: true, normalized };
+};
+
+export const generateCuil = (dni: string, sexo: Sexo): string => {
+  const normalizedDni = normalizeDni(dni);
+  const digits = normalizedDni.padStart(8, "0");
+  const base = sexo === "M" ? "20" : "27";
+  const factors = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2];
+
+  const calcDv = (prefix: string): number => {
+    const raw = `${prefix}${digits}`.split("").map((item) => Number(item));
+    const total = raw.reduce((acc, num, index) => acc + num * factors[index], 0);
+    const remainder = total % 11;
+    return 11 - remainder;
+  };
+
+  let prefix = base;
+  let dv = calcDv(prefix);
+
+  if (dv === 11) dv = 0;
+  if (dv === 10) {
+    prefix = "23";
+    dv = sexo === "M" ? 9 : 4;
+  }
+
+  return `${prefix}-${digits}-${dv}`;
+};
+
+const formatDate = (date: Date): string => {
+  const day = `${date.getDate()}`.padStart(2, "0");
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const year = date.getFullYear();
+  const hour = `${date.getHours()}`.padStart(2, "0");
+  const minute = `${date.getMinutes()}`.padStart(2, "0");
+  return `${day}-${month}-${year} ${hour}:${minute}`;
+};
+
+export const nowAsDisplayDate = (): string => formatDate(new Date());
+
+export const getSubactivityPrompt = (actividad: Actividad): string => {
+  const promptMap: Partial<Record<Actividad, string>> = {
+    Jubilado: "Gracias, su jubilación pertenece a:",
+    "Pensión por viudez": "Gracias, su pensión pertenece a:",
+    Docente: "Gracias, su actividad de docente pertenece a:",
+    Policía: "Gracias, su actividad de policía pertenece a:",
+    Pensiones: "Gracias, su pensión corresponde a:",
+    "Empleado público": "Gracias, su empleo público pertenece a:",
+  };
+  return promptMap[actividad] ?? "Gracias. Continuamos con su evaluación.";
+};
+
+export type BcraMockData = {
+  totalSituaciones: number;
+  irregulares: number;
+  tieneSituacion1: boolean;
+};
+
+export const mockBcraData: BcraMockData = {
+  totalSituaciones: 1,
+  irregulares: 0,
+  tieneSituacion1: true,
+};
+
+export const evaluateLead = (lead: LeadData, bcraData: BcraMockData): Resultado => {
+  // TODO BCRA Jubilado/Viudez/Pensiones: >2 irregulares => "Afectado"; si no, guardar mayor situación.
+  // TODO BCRA Docente/Policía/Empleados/Otros: >1 situación mayor a 1 => "Afectado"; si no, guardar mayor situación.
+  // TODO BCRA AUH: >1 situación mayor a 1 o sin situación 1 => "Afectado"; con situación 1 y sin irregularidades => "1".
+  // TODO: Reemplazar por evaluación real con BCRA.
+  const { irregulares, totalSituaciones, tieneSituacion1 } = bcraData;
+
+  if (!lead.actividad) return "revision_manual";
+  if (lead.actividad === "Empleado provincial de Santa Fe" || lead.actividad === "Empleado provincial Chubut" || lead.actividad === "No estoy seguro / Otro") return "revision_manual";
+  if (lead.actividad === "Jubilado" || lead.actividad === "Pensión por viudez") return irregulares <= 2 ? "precalifica_haberes_cbu" : "precalifica_haberes";
+  if (lead.actividad === "Docente" && lead.subActividad === "Privada") return tieneSituacion1 && irregulares === 0 ? "precalifica_cbu" : "rechazado";
+  if (lead.actividad === "Docente") return irregulares === 0 ? "precalifica_haberes_cbu" : "precalifica_haberes";
+  if (lead.actividad === "Policía") return irregulares === 0 ? "precalifica_haberes_cbu" : "precalifica_haberes";
+  if (lead.actividad === "AUH") return tieneSituacion1 && irregulares === 0 ? "precalifica_cbu" : "rechazado";
+  if (lead.actividad === "Pensiones") {
+    if (lead.subActividad === "Otro") return "revision_manual";
+    return irregulares <= 2 ? "precalifica_haberes_cbu" : "rechazado";
+  }
+  if (lead.actividad === "Empleado GCBA") {
+    if (totalSituaciones === 0) return "revision_manual";
+    return irregulares / totalSituaciones > 0.4 ? "precalifica_haberes" : "precalifica_haberes_cbu";
+  }
+  if (lead.actividad === "Empleado público" && (lead.subActividad === "Nacional" || lead.subActividad === "Municipal")) {
+    return tieneSituacion1 && irregulares === 0 ? "precalifica_cbu" : "rechazado";
+  }
+  if (lead.actividad === "Empleado público" && lead.subActividad === "Provincial") {
+    if (totalSituaciones === 0) return "revision_manual";
+    return irregulares / totalSituaciones > 0.4 ? "precalifica_haberes" : "precalifica_haberes_cbu";
+  }
+
+  return "revision_manual";
+};
+
+export const toVisibleResult = (resultado: Resultado): string => {
+  const map: Record<Resultado, string> = {
+    precalifica_cbu: "Precalifica CBU",
+    precalifica_haberes_cbu: "Precalifica Haberes y CBU",
+    precalifica_haberes: "Precalifica Haberes",
+    revision_manual: "Requiere revisión por operador",
+    rechazado: "Rechazado",
+  };
+  return map[resultado];
+};
+
+export const buildWhatsAppMessage = (lead: LeadData): string => {
+  const lines = [
+    "Hola, me asesoró María de Credizza.",
+    "Comparto una precalificación:",
+    `* Actividad: ${lead.actividad ?? "No informado"}`,
+    ...(lead.subActividad ? [`* Subactividad: ${lead.subActividad}`] : []),
+    `* Banco: ${lead.banco ?? "No informado"}`,
+    `* DNI: ${lead.dni ?? "No informado"}`,
+    `* CUIL: ${lead.cuil ?? "No informado"}`,
+    `* Sexo: ${lead.sexo ?? "No informado"}`,
+    `* Resultado: ${lead.resultado || "No informado"}`,
+    `* Fecha: ${lead.fecha}`,
+  ];
+
+  return encodeURIComponent(lines.join("\n"));
+};
+
+export const saveLeadMock = async (lead: LeadData): Promise<void> => {
+  try {
+    await fetch("/api/leads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(lead),
+    });
+  } catch (error) {
+    console.error("Error enviando lead a /api/leads", error);
+  }
+};

--- a/src/types/googleapis.d.ts
+++ b/src/types/googleapis.d.ts
@@ -1,0 +1,29 @@
+declare module "googleapis" {
+  type AppendParams = {
+    spreadsheetId: string;
+    range: string;
+    valueInputOption: "USER_ENTERED" | "RAW";
+    requestBody: {
+      values: string[][];
+    };
+  };
+
+  type JWTConfig = {
+    email: string;
+    key: string;
+    scopes: string[];
+  };
+
+  export const google: {
+    auth: {
+      JWT: new (config: JWTConfig) => unknown;
+    };
+    sheets: (config: { version: "v4"; auth: unknown }) => {
+      spreadsheets: {
+        values: {
+          append: (params: AppendParams) => Promise<unknown>;
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
### Motivation

- Provide an interactive precalification chat assistant (María) to collect lead data and evaluate preliminary results client-side.
- Persist captured leads to Google Sheets via a new serverless API route to centralize lead storage. 
- Prepare types and utilities to standardize lead data, DNI/CUIL handling and mock BCRA evaluation for later integration. 

### Description

- Added a client chat component `src/components/chat/MariaCredizzaChat.tsx` with UI flow and state handling for actividad, subactividad, banco, DNI, sexo and WhatsApp flows. 
- Introduced supporting types and utilities in `src/components/chat/mariaCredizzaChat.types.ts` and `src/components/chat/mariaCredizzaChat.utils.ts` including DNI normalization, `generateCuil`, lead building, mock BCRA evaluation, and `saveLeadMock` which posts to the new API. 
- Implemented a Next API route `src/app/api/leads/route.ts` that validates required fields and appends lead rows to Google Sheets using the `googleapis` JWT client and `sheets.spreadsheets.values.append`; environment variables `GOOGLE_SHEET_ID`, `GOOGLE_CLIENT_EMAIL`, and `GOOGLE_PRIVATE_KEY` are required. 
- Added `googleapis` to `package.json` and a minimal ambient declaration in `src/types/googleapis.d.ts`; also added a test page `src/app/test-chat/page.tsx` to preview the chat. 
- Marked BCRA integration TODOs and left evaluation logic mocked in `mariaCredizzaChat.utils.ts` so it can be replaced with real BCRA lookups later. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17eb15614832188547e5f3f6d45ba)