### PR TITLE
fix(chat): auto-scroll al final del flujo en MariaCredizzaChat

### DIFF
--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -66,8 +66,6 @@ export default function MariaCredizzaChat() {
   const [showFullBankSearch, setShowFullBankSearch] = useState(true);
   const [dniInput, setDniInput] = useState("");
   const [dniError, setDniError] = useState("");
-  const [whatsInput, setWhatsInput] = useState("");
-  const [whatsError, setWhatsError] = useState("");
   const chatScrollRef = useRef<HTMLDivElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
@@ -96,8 +94,6 @@ export default function MariaCredizzaChat() {
     setShowFullBankSearch(true);
     setDniInput("");
     setDniError("");
-    setWhatsInput("");
-    setWhatsError("");
   };
 
   const goToBankStep = (actividad: Actividad, subActividad: SubActividad | null): void => {
@@ -213,34 +209,24 @@ export default function MariaCredizzaChat() {
 
   const onWhatsappChoice = async (yes: boolean): Promise<void> => {
     addUser(yes ? "Sí" : "No");
-    const leadToSave: LeadData = buildLeadData({ ...lead });
-    await saveLeadMock(leadToSave);
+
     if (yes) {
-      const mensaje = buildWhatsAppMessage(leadToSave);
-      const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(mensaje)}`;
+      const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "Derivado a WhatsApp" });
+      setLead(leadToSave);
+      await saveLeadMock(leadToSave);
+      const message = buildWhatsAppMessage(leadToSave);
+      const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(message)}`;
       window.open(whatsappUrl, "_blank", "noopener,noreferrer");
-      addBot("Perfecto. Un asesor le responderá a la brevedad vía WhatsApp.");
+      addBot("Gracias. Será atendido por WhatsApp.");
       setStep("fin");
       return;
     }
-    addBot("Para que un asesor pueda continuar luego con su evaluación, indique su número de WhatsApp.");
-    setStep("fin");
-  };
 
-  const onManualWhatsapp = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
-    event.preventDefault();
-    const cleaned = whatsInput.replace(/\D/g, "");
-    if (cleaned.length < 8) {
-      setWhatsError("Ingrese un número de WhatsApp válido.");
-      return;
-    }
-    setWhatsError("");
-    const updated: LeadData = buildLeadData({ ...lead, whatsapp: cleaned });
-    setLead(updated);
-    await saveLeadMock(updated);
-    addUser(cleaned);
-    addBot("Gracias por completar la precalificación. Un asesor podrá contactarle a la brevedad.");
-    setWhatsInput("");
+    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "No continuó por WhatsApp" });
+    setLead(leadToSave);
+    await saveLeadMock(leadToSave);
+    addBot("Gracias por completar la precalificación.");
+    setStep("fin");
   };
 
   return (
@@ -270,7 +256,6 @@ export default function MariaCredizzaChat() {
 
       {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
       {step === "whatsapp" && <div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => void onWhatsappChoice(true)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Sí</button><button type="button" onClick={() => void onWhatsappChoice(false)} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones">No</button></div>}
-      {step === "fin" && <form onSubmit={(e) => void onManualWhatsapp(e)} className="space-y-2"><input value={whatsInput} onChange={(e) => setWhatsInput(e.target.value)} placeholder="Número de WhatsApp" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{whatsError && <p className="text-smallMobile text-boton-secundario">{whatsError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Guardar número</button></form>}
       {showBackButton && <button type="button" onClick={onBack} className="mt-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
     </section>
   );

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Actividad, ChatStep, LeadData, Sexo, SubActividad } from "./mariaCredizzaChat.types";
 import {
   ACTIVIDADES_DISPONIBLES,
@@ -68,12 +68,17 @@ export default function MariaCredizzaChat() {
   const [dniError, setDniError] = useState("");
   const [whatsInput, setWhatsInput] = useState("");
   const [whatsError, setWhatsError] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   const actividadFiltrada = useMemo(() => ACTIVIDADES_DISPONIBLES.filter((item) => item.toLowerCase().includes(actividadInput.toLowerCase())), [actividadInput]);
   const bancosFiltrados = useMemo(() => BANCOS_DISPONIBLES.filter((item) => item.toLowerCase().includes(bancoInput.toLowerCase())), [bancoInput]);
 
   const addBot = (text: string): void => setMessages((prev) => [...prev, { from: "bot", text }]);
   const addUser = (text: string): void => setMessages((prev) => [...prev, { from: "user", text }]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [step, messages, subOptions, secondSubOptions, suggestedBank, showFullBankSearch, bancosFiltrados, actividadFiltrada]);
 
   const resetChat = (): void => {
     setStep("inicio");
@@ -245,6 +250,7 @@ export default function MariaCredizzaChat() {
             {m.text}
           </div>
         ))}
+        <div ref={messagesEndRef} />
       </div>
 
       {showBackButton && <button type="button" onClick={onBack} className="mb-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { Actividad, ChatStep, LeadData, Sexo, SubActividad } from "./mariaCredizzaChat.types";
 import {
   ACTIVIDADES_DISPONIBLES,
@@ -68,17 +68,12 @@ export default function MariaCredizzaChat() {
   const [dniError, setDniError] = useState("");
   const [whatsInput, setWhatsInput] = useState("");
   const [whatsError, setWhatsError] = useState("");
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
   const actividadFiltrada = useMemo(() => ACTIVIDADES_DISPONIBLES.filter((item) => item.toLowerCase().includes(actividadInput.toLowerCase())), [actividadInput]);
   const bancosFiltrados = useMemo(() => BANCOS_DISPONIBLES.filter((item) => item.toLowerCase().includes(bancoInput.toLowerCase())), [bancoInput]);
 
   const addBot = (text: string): void => setMessages((prev) => [...prev, { from: "bot", text }]);
   const addUser = (text: string): void => setMessages((prev) => [...prev, { from: "user", text }]);
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [step, messages, subOptions, secondSubOptions, suggestedBank, showFullBankSearch, bancosFiltrados, actividadFiltrada]);
 
   const resetChat = (): void => {
     setStep("inicio");
@@ -250,22 +245,21 @@ export default function MariaCredizzaChat() {
             {m.text}
           </div>
         ))}
-        <div ref={messagesEndRef} />
       </div>
 
-      {showBackButton && <button type="button" onClick={onBack} className="mb-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
 
       {(step === "inicio" || step === "actividad") && <div className="space-y-2"><input value={actividadInput} onChange={(e) => setActividadInput(e.target.value)} placeholder="Buscar actividad" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" /><div className="max-h-40 overflow-y-auto rounded-xl border border-sistema-uno">{actividadFiltrada.map((act) => <button key={act} type="button" onClick={() => onActividad(act)} className="block w-full border-b border-sistema-uno px-3 py-2 text-left text-small text-texto-principal">{act}</button>)}</div></div>}
 
       {step === "subActividad" && <div className="grid grid-cols-1 gap-2">{(secondSubOptions.length > 0 ? secondSubOptions : subOptions).map((item) => <button key={item} type="button" onClick={() => onSubActivity(item)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small text-texto-principal">{item}</button>)}</div>}
 
-      {step === "banco" && <div className="space-y-2">{suggestedBank && !showFullBankSearch ? <div className="grid grid-cols-1 gap-2"><button type="button" onClick={() => onBanco(suggestedBank)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">{suggestedBank}</button><button type="button" onClick={() => setShowFullBankSearch(true)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">Otro banco</button></div> : <><input value={bancoInput} onChange={(e) => setBancoInput(e.target.value)} placeholder="Buscar banco" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" /><div className="max-h-28 overflow-y-auto rounded-xl border border-sistema-uno">{bancosFiltrados.map((bank) => <button key={bank} type="button" onClick={() => onBanco(bank)} className="block w-full border-b border-sistema-uno px-3 py-2 text-left text-small">{bank}</button>)}</div></>}<div className="flex flex-col gap-1"><button type="button" onClick={() => setShowFullBankSearch(true)} className="text-left text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">No encuentro mi banco</button><button type="button" onClick={onBack} className="text-left text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button></div></div>}
+      {step === "banco" && <div className="space-y-2">{suggestedBank && !showFullBankSearch ? <div className="grid grid-cols-1 gap-2"><button type="button" onClick={() => onBanco(suggestedBank)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">{suggestedBank}</button><button type="button" onClick={() => setShowFullBankSearch(true)} className="rounded-xl border border-sistema-uno px-3 py-2 text-left text-small">Otro banco</button></div> : <><input value={bancoInput} onChange={(e) => setBancoInput(e.target.value)} placeholder="Buscar banco" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" /><div className="max-h-28 overflow-y-auto rounded-xl border border-sistema-uno">{bancosFiltrados.map((bank) => <button key={bank} type="button" onClick={() => onBanco(bank)} className="block w-full border-b border-sistema-uno px-3 py-2 text-left text-small">{bank}</button>)}</div></>}<div className="flex flex-col gap-1"><button type="button" onClick={() => setShowFullBankSearch(true)} className="text-left text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">No encuentro mi banco</button></div></div>}
 
       {step === "dni" && <form onSubmit={onDni} className="space-y-2"><input value={dniInput} onChange={(e) => setDniInput(e.target.value)} placeholder="Ingrese DNI" inputMode="numeric" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{dniError && <p className="text-smallMobile text-boton-secundario">{dniError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Continuar</button></form>}
 
       {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
       {step === "whatsapp" && <div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => void onWhatsappChoice(true)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Sí</button><button type="button" onClick={() => void onWhatsappChoice(false)} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones">No</button></div>}
       {step === "fin" && <form onSubmit={(e) => void onManualWhatsapp(e)} className="space-y-2"><input value={whatsInput} onChange={(e) => setWhatsInput(e.target.value)} placeholder="Número de WhatsApp" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{whatsError && <p className="text-smallMobile text-boton-secundario">{whatsError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Guardar número</button></form>}
+      {showBackButton && <button type="button" onClick={onBack} className="mt-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
     </section>
   );
 }

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Actividad, ChatStep, LeadData, Sexo, SubActividad } from "./mariaCredizzaChat.types";
 import {
   ACTIVIDADES_DISPONIBLES,
@@ -68,12 +68,21 @@ export default function MariaCredizzaChat() {
   const [dniError, setDniError] = useState("");
   const [whatsInput, setWhatsInput] = useState("");
   const [whatsError, setWhatsError] = useState("");
+  const chatScrollRef = useRef<HTMLDivElement | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
 
   const actividadFiltrada = useMemo(() => ACTIVIDADES_DISPONIBLES.filter((item) => item.toLowerCase().includes(actividadInput.toLowerCase())), [actividadInput]);
   const bancosFiltrados = useMemo(() => BANCOS_DISPONIBLES.filter((item) => item.toLowerCase().includes(bancoInput.toLowerCase())), [bancoInput]);
 
   const addBot = (text: string): void => setMessages((prev) => [...prev, { from: "bot", text }]);
   const addUser = (text: string): void => setMessages((prev) => [...prev, { from: "user", text }]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    if (chatScrollRef.current) {
+      chatScrollRef.current.scrollTop = chatScrollRef.current.scrollHeight;
+    }
+  }, [step, messages, lead, subOptions, secondSubOptions, showFullBankSearch, suggestedBank, actividadFiltrada, bancosFiltrados]);
 
   const resetChat = (): void => {
     setStep("inicio");
@@ -239,12 +248,13 @@ export default function MariaCredizzaChat() {
         <button type="button" onClick={resetChat} className="text-small text-texto-secundario underline">Reiniciar</button>
       </div>
 
-      <div className="mb-4 flex max-h-[60vh] flex-col gap-2 overflow-y-auto rounded-xl bg-background-default p-3">
+      <div ref={chatScrollRef} className="mb-4 flex max-h-[60vh] flex-col gap-2 overflow-y-auto rounded-xl bg-background-default p-3">
         {messages.map((m, i) => (
           <div key={`${m.from}-${i}`} className={`max-w-[90%] rounded-2xl px-3 py-2 text-small ${m.from === "bot" ? "self-start bg-background-secondary text-texto-principal" : "self-end bg-boton-primario text-texto-botones"}`}>
             {m.text}
           </div>
         ))}
+        <div ref={bottomRef} />
       </div>
 
 

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -67,6 +67,9 @@ export default function MariaCredizzaChat() {
   const [dniInput, setDniInput] = useState("");
   const [dniError, setDniError] = useState("");
   const [isWhatsappLoading, setIsWhatsappLoading] = useState(false);
+  const [contactInput, setContactInput] = useState("");
+  const [contactError, setContactError] = useState("");
+  const [isAlternateContactSaved, setIsAlternateContactSaved] = useState(false);
   const chatScrollRef = useRef<HTMLDivElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
@@ -96,6 +99,9 @@ export default function MariaCredizzaChat() {
     setDniInput("");
     setDniError("");
     setIsWhatsappLoading(false);
+    setContactInput("");
+    setContactError("");
+    setIsAlternateContactSaved(false);
   };
 
   const goToBankStep = (actividad: Actividad, subActividad: SubActividad | null): void => {
@@ -133,7 +139,7 @@ export default function MariaCredizzaChat() {
     }
   };
 
-  const showBackButton = step === "subActividad" || step === "banco" || step === "dni" || step === "sexo";
+  const showBackButton = step === "subActividad" || step === "banco" || step === "dni" || step === "sexo" || step === "fin";
 
   const onActividad = (actividad: Actividad): void => {
     addUser(actividad);
@@ -209,6 +215,16 @@ export default function MariaCredizzaChat() {
     setStep("whatsapp");
   };
 
+
+  const isValidEmail = (value: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+  const isValidPhone = (value: string): boolean => value.replace(/\D/g, "").length >= 8;
+
+  const isValidAlternateContact = (value: string): boolean => {
+    const trimmed = value.trim();
+    return Boolean(trimmed) && (isValidEmail(trimmed) || isValidPhone(trimmed));
+  };
+
   const onWhatsappChoice = async (yes: boolean): Promise<void> => {
     if (isWhatsappLoading) return;
     addUser(yes ? "Sí" : "No");
@@ -230,11 +246,31 @@ export default function MariaCredizzaChat() {
       return;
     }
 
-    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "No continuó por WhatsApp" });
+    addBot("Para que un asesor pueda contactarle luego, indique un email o teléfono de contacto.");
+    setContactInput("");
+    setContactError("");
+    setIsAlternateContactSaved(false);
+    setStep("fin");
+  };
+
+
+  const onAlternateContactSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    const trimmed = contactInput.trim();
+
+    if (!isValidAlternateContact(trimmed)) {
+      setContactError("Por favor ingrese un email o teléfono válido.");
+      return;
+    }
+
+    setContactError("");
+    setIsAlternateContactSaved(false);
+    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: `No continuó por WhatsApp - Contacto: ${trimmed}` });
     setLead(leadToSave);
     await saveLeadMock(leadToSave);
-    addBot("Gracias por completar la precalificación.");
-    setStep("fin");
+    addUser(trimmed);
+    addBot("Gracias por completar la precalificación. Un asesor podrá contactarle a la brevedad.");
+    setIsAlternateContactSaved(true);
   };
 
   return (
@@ -264,6 +300,7 @@ export default function MariaCredizzaChat() {
 
       {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
       {step === "whatsapp" && <div className="space-y-2">{isWhatsappLoading && <div className="flex items-center gap-2 rounded-xl border border-sistema-uno bg-background-default px-3 py-2 text-small text-texto-secundario"><span className="inline-block animate-bounce" aria-hidden="true">📱</span><span>Estamos preparando su atención...</span></div>}<div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => void onWhatsappChoice(true)} disabled={isWhatsappLoading} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones disabled:cursor-not-allowed disabled:opacity-60">Sí</button><button type="button" onClick={() => void onWhatsappChoice(false)} disabled={isWhatsappLoading} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones disabled:cursor-not-allowed disabled:opacity-60">No</button></div></div>}
+      {step === "fin" && !isAlternateContactSaved && <form onSubmit={(e) => void onAlternateContactSubmit(e)} className="space-y-2"><input value={contactInput} onChange={(e) => setContactInput(e.target.value)} placeholder="Email o teléfono" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{contactError && <p className="text-smallMobile text-boton-secundario">{contactError}</p>}<button type="submit" disabled={!isValidAlternateContact(contactInput)} className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones disabled:cursor-not-allowed disabled:opacity-60">Guardar contacto</button></form>}
       {showBackButton && <button type="button" onClick={onBack} className="mt-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
     </section>
   );

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -199,7 +199,7 @@ export default function MariaCredizzaChat() {
 
   const onSexo = async (sexo: Sexo): Promise<void> => {
     addUser(sexo);
-    const cuil = lead.dni ? generateCuil(lead.dni, sexo) : "";
+    const cuil = lead.dni ? generateCuil(lead.dni, sexo).replace(/\D/g, "") : "";
     const updatedLead: LeadData = buildLeadData({ ...lead, sexo, cuil, fecha: nowAsDisplayDate() });
     addBot("Procesando información...");
     setStep("procesando");
@@ -265,7 +265,7 @@ export default function MariaCredizzaChat() {
 
     setContactError("");
     setIsAlternateContactSaved(false);
-    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: `No continuó por WhatsApp - Contacto: ${trimmed}` });
+    const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: `Contacto: ${trimmed}` });
     setLead(leadToSave);
     await saveLeadMock(leadToSave);
     addUser(trimmed);

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -66,6 +66,7 @@ export default function MariaCredizzaChat() {
   const [showFullBankSearch, setShowFullBankSearch] = useState(true);
   const [dniInput, setDniInput] = useState("");
   const [dniError, setDniError] = useState("");
+  const [isWhatsappLoading, setIsWhatsappLoading] = useState(false);
   const chatScrollRef = useRef<HTMLDivElement | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
@@ -94,6 +95,7 @@ export default function MariaCredizzaChat() {
     setShowFullBankSearch(true);
     setDniInput("");
     setDniError("");
+    setIsWhatsappLoading(false);
   };
 
   const goToBankStep = (actividad: Actividad, subActividad: SubActividad | null): void => {
@@ -208,15 +210,21 @@ export default function MariaCredizzaChat() {
   };
 
   const onWhatsappChoice = async (yes: boolean): Promise<void> => {
+    if (isWhatsappLoading) return;
     addUser(yes ? "Sí" : "No");
 
     if (yes) {
-      const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "Derivado a WhatsApp" });
-      setLead(leadToSave);
-      await saveLeadMock(leadToSave);
-      const message = buildWhatsAppMessage(leadToSave);
-      const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(message)}`;
-      window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+      setIsWhatsappLoading(true);
+      try {
+        const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "Derivado a WhatsApp" });
+        setLead(leadToSave);
+        await saveLeadMock(leadToSave);
+        const message = buildWhatsAppMessage(leadToSave);
+        const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(message)}`;
+        window.open(whatsappUrl, "_blank", "noopener,noreferrer");
+      } finally {
+        setIsWhatsappLoading(false);
+      }
       addBot("Gracias. Será atendido por WhatsApp.");
       setStep("fin");
       return;
@@ -255,7 +263,7 @@ export default function MariaCredizzaChat() {
       {step === "dni" && <form onSubmit={onDni} className="space-y-2"><input value={dniInput} onChange={(e) => setDniInput(e.target.value)} placeholder="Ingrese DNI" inputMode="numeric" className="w-full rounded-xl border border-sistema-uno px-3 py-2 text-small" />{dniError && <p className="text-smallMobile text-boton-secundario">{dniError}</p>}<button type="submit" className="w-full rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Continuar</button></form>}
 
       {step === "sexo" && <div className="grid grid-cols-2 gap-2">{(["F", "M"] as const).map((sexo) => <button key={sexo} type="button" onClick={() => void onSexo(sexo)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">{sexo}</button>)}</div>}
-      {step === "whatsapp" && <div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => void onWhatsappChoice(true)} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones">Sí</button><button type="button" onClick={() => void onWhatsappChoice(false)} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones">No</button></div>}
+      {step === "whatsapp" && <div className="space-y-2">{isWhatsappLoading && <div className="flex items-center gap-2 rounded-xl border border-sistema-uno bg-background-default px-3 py-2 text-small text-texto-secundario"><span className="inline-block animate-bounce" aria-hidden="true">📱</span><span>Estamos preparando su atención...</span></div>}<div className="grid grid-cols-2 gap-2"><button type="button" onClick={() => void onWhatsappChoice(true)} disabled={isWhatsappLoading} className="rounded-xl bg-boton-primario px-3 py-2 text-button text-texto-botones disabled:cursor-not-allowed disabled:opacity-60">Sí</button><button type="button" onClick={() => void onWhatsappChoice(false)} disabled={isWhatsappLoading} className="rounded-xl bg-boton-neutral px-3 py-2 text-button text-texto-botones disabled:cursor-not-allowed disabled:opacity-60">No</button></div></div>}
       {showBackButton && <button type="button" onClick={onBack} className="mt-2 text-small text-texto-secundario transition-opacity hover:opacity-80 cursor-pointer">← Cambiar respuesta</button>}
     </section>
   );

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -216,7 +216,9 @@ export default function MariaCredizzaChat() {
     const leadToSave: LeadData = buildLeadData({ ...lead });
     await saveLeadMock(leadToSave);
     if (yes) {
-      window.open(`https://wa.me/?text=${buildWhatsAppMessage(leadToSave)}`, "_blank", "noopener,noreferrer");
+      const mensaje = buildWhatsAppMessage(leadToSave);
+      const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(mensaje)}`;
+      window.open(whatsappUrl, "_blank", "noopener,noreferrer");
       addBot("Perfecto. Un asesor le responderá a la brevedad vía WhatsApp.");
       setStep("fin");
       return;

--- a/src/components/chat/mariaCredizzaChat.utils.ts
+++ b/src/components/chat/mariaCredizzaChat.utils.ts
@@ -243,7 +243,7 @@ export const buildWhatsAppMessage = (lead: LeadData): string => {
     `* Fecha: ${lead.fecha}`,
   ];
 
-  return encodeURIComponent(lines.join("\n"));
+  return lines.join("\n");
 };
 
 export const saveLeadMock = async (lead: LeadData): Promise<void> => {


### PR DESCRIPTION
### Motivation
- Asegurar que el contenedor del chat baje automáticamente al final cada vez que avance el flujo o se agregue una nueva respuesta/opción para que siempre se vea la última pregunta y sus botones en desktop y mobile.

### Description
- Se agregó `messagesEndRef` usando `useRef<HTMLDivElement | null>` y se colocó `<div ref={messagesEndRef} />` al final del listado de mensajes. 
- Se añadió un `useEffect` que ejecuta `messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" })` cuando cambia `step` o los datos que renderizan el flujo (`messages`, `subOptions`, `secondSubOptions`, `suggestedBank`, `showFullBankSearch`, `bancosFiltrados`, `actividadFiltrada`).
- Se actualizaron las importaciones para incluir `useEffect` y `useRef`, sin modificar reglas de negocio, textos, integraciones externas ni columnas de Sheets, y manteniendo TypeScript estricto sin `any`.

### Testing
- Ejecutado `npm run lint` y finalizó correctamente (solo warnings preexistentes sin relación con este cambio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f552bc467083219bebf2b4dcffc9d1)