### PR TITLE
Manejar fallos de red en BCRA con respuesta 503 controlada

### DIFF
--- a/src/app/api/bcra/route.ts
+++ b/src/app/api/bcra/route.ts
@@ -87,11 +87,23 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "El campo cuil debe tener exactamente 11 dígitos." }, { status: 400 });
   }
 
-  const bcraResponse = await fetch(`https://api.bcra.gob.ar/CentralDeDeudores/v1.0/Deudas/${cuil}`, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-    cache: "no-store",
-  });
+  let bcraResponse: Response;
+
+  try {
+    bcraResponse = await fetch(`https://api.bcra.gob.ar/CentralDeDeudores/v1.0/Deudas/${cuil}`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        message: "No se pudo conectar con BCRA. Intentá nuevamente.",
+      },
+      { status: 503 },
+    );
+  }
 
   if (bcraResponse.status === 404) {
     return NextResponse.json(buildEmptyResponse(cuil));


### PR DESCRIPTION
### Motivation
- Evitar que errores de red en la llamada a la API del BCRA provoquen un error 500 no controlado y devolver un JSON claro con status 503 cuando no se pueda conectar.

### Description
- Se envolvió únicamente la llamada `fetch` en `src/app/api/bcra/route.ts` dentro de un `try/catch` que devuelve `NextResponse.json({ success: false, message: "No se pudo conectar con BCRA. Intentá nuevamente." }, { status: 503 })` en caso de fallo de conexión, manteniendo las validaciones de CUIL (incluyendo el chequeo de 11 dígitos) y la normalización de la respuesta; no se introdujo `any` ni se cambiaron otras integraciones.

### Testing
- Se ejecutaron comprobaciones de control de cambios con `git status --short`, `git diff -- src/app/api/bcra/route.ts` y se realizó el `git commit`, todos exitosos; no se añadieron ni ejecutaron tests automatizados adicionales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03cf04dbfc83218f0cf2c38d372046)