### PR TITLE
Integrar consulta BCRA al guardado final de leads

### DIFF
--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -13,6 +13,13 @@ type LeadData = {
   banco: string;
   whatsapp?: string;
   resultado: string;
+  bcraEstadoConsulta?: string;
+  bcraNombre?: string;
+  bcraTieneSituacion1?: string;
+  bcraCantidadTotal?: string;
+  bcraCantidadIrregulares?: string;
+  bcraMayorSituacion?: string;
+  bcraDetalle?: string;
 };
 
 const requiredFields: Array<keyof Pick<LeadData, "fecha" | "dni" | "cuil" | "actividad" | "banco" | "resultado">> = ["fecha", "dni", "cuil", "actividad", "banco", "resultado"];
@@ -41,14 +48,30 @@ export async function POST(request: Request) {
     const auth = new google.auth.JWT({ email: clientEmail, key: privateKey, scopes: ["https://www.googleapis.com/auth/spreadsheets"] });
     const sheets = google.sheets({ version: "v4", auth });
 
-    // TODO: Integrar BCRA para completar nombreApellido real.
-    // TODO: Integrar BCRA para calcular situacionBcra real.
-    // TODO: Reemplazar valores mock por respuesta real de BCRA.
-    const row = [lead.fecha, lead.nombreApellido, lead.sexo, lead.dni, lead.cuil, lead.actividad, lead.subActividad || "", lead.situacionBcra, lead.banco, lead.whatsapp || "", lead.resultado];
+    const row = [
+      lead.fecha,
+      lead.nombreApellido,
+      lead.sexo,
+      lead.dni,
+      lead.cuil,
+      lead.actividad,
+      lead.subActividad || "",
+      lead.situacionBcra,
+      lead.banco,
+      lead.whatsapp || "",
+      lead.resultado,
+      lead.bcraEstadoConsulta || "No disponible",
+      lead.bcraNombre || "",
+      lead.bcraTieneSituacion1 || "",
+      lead.bcraCantidadTotal || "",
+      lead.bcraCantidadIrregulares || "",
+      lead.bcraMayorSituacion || "",
+      lead.bcraDetalle || "",
+    ];
 
     await sheets.spreadsheets.values.append({
       spreadsheetId: sheetId,
-      range: "'Hoja 1'!A:K",
+      range: "'Leads Credizza - Precalificador Web'!A:R",
       valueInputOption: "USER_ENTERED",
       requestBody: { values: [row] },
     });

--- a/src/components/chat/MariaCredizzaChat.tsx
+++ b/src/components/chat/MariaCredizzaChat.tsx
@@ -15,6 +15,7 @@ import {
   nowAsDisplayDate,
   saveLeadMock,
   toVisibleResult,
+  enrichLeadWithBcra,
   validateDni,
 } from "./mariaCredizzaChat.utils";
 
@@ -233,9 +234,10 @@ export default function MariaCredizzaChat() {
       setIsWhatsappLoading(true);
       try {
         const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: "Derivado a WhatsApp" });
-        setLead(leadToSave);
-        await saveLeadMock(leadToSave);
-        const message = buildWhatsAppMessage(leadToSave);
+        const leadWithBcra = await enrichLeadWithBcra(leadToSave);
+        setLead(leadWithBcra);
+        await saveLeadMock(leadWithBcra);
+        const message = buildWhatsAppMessage(leadWithBcra);
         const whatsappUrl = `https://wa.me/5491166669143?text=${encodeURIComponent(message)}`;
         window.open(whatsappUrl, "_blank", "noopener,noreferrer");
       } finally {
@@ -266,8 +268,9 @@ export default function MariaCredizzaChat() {
     setContactError("");
     setIsAlternateContactSaved(false);
     const leadToSave: LeadData = buildLeadData({ ...lead, whatsapp: `Contacto: ${trimmed}` });
-    setLead(leadToSave);
-    await saveLeadMock(leadToSave);
+    const leadWithBcra = await enrichLeadWithBcra(leadToSave);
+    setLead(leadWithBcra);
+    await saveLeadMock(leadWithBcra);
     addUser(trimmed);
     addBot("Gracias por completar la precalificación. Un asesor podrá contactarle a la brevedad.");
     setIsAlternateContactSaved(true);

--- a/src/components/chat/mariaCredizzaChat.types.ts
+++ b/src/components/chat/mariaCredizzaChat.types.ts
@@ -61,4 +61,11 @@ export type LeadData = {
   banco: string;
   whatsapp: string;
   resultado: string;
+  bcraEstadoConsulta: string;
+  bcraNombre: string;
+  bcraTieneSituacion1: string;
+  bcraCantidadTotal: string;
+  bcraCantidadIrregulares: string;
+  bcraMayorSituacion: string;
+  bcraDetalle: string;
 };

--- a/src/components/chat/mariaCredizzaChat.utils.ts
+++ b/src/components/chat/mariaCredizzaChat.utils.ts
@@ -1,4 +1,4 @@
-import { Actividad, LeadData, Resultado, Sexo, SubActividad } from "./mariaCredizzaChat.types";
+import { Actividad, LeadData, Resultado, Sexo } from "./mariaCredizzaChat.types";
 
 export const ACTIVIDADES_DISPONIBLES: readonly Actividad[] = [
   "Jubilado",
@@ -108,6 +108,13 @@ export const buildLeadData = (partial: Partial<LeadData>): LeadData => ({
   banco: partial.banco ?? "",
   whatsapp: partial.whatsapp ?? "",
   resultado: partial.resultado ?? "",
+  bcraEstadoConsulta: partial.bcraEstadoConsulta ?? "Pendiente",
+  bcraNombre: partial.bcraNombre ?? "",
+  bcraTieneSituacion1: partial.bcraTieneSituacion1 ?? "",
+  bcraCantidadTotal: partial.bcraCantidadTotal ?? "",
+  bcraCantidadIrregulares: partial.bcraCantidadIrregulares ?? "",
+  bcraMayorSituacion: partial.bcraMayorSituacion ?? "",
+  bcraDetalle: partial.bcraDetalle ?? "",
 });
 
 export const normalizeDni = (value: string): string => {
@@ -255,5 +262,68 @@ export const saveLeadMock = async (lead: LeadData): Promise<void> => {
     });
   } catch (error) {
     console.error("Error enviando lead a /api/leads", error);
+  }
+};
+
+type BcraSituacion = {
+  entidad: string;
+  situacion: number;
+  monto: number;
+  diasAtrasoPago: number;
+};
+
+type BcraApiResponse = {
+  success: boolean;
+  cuil: string;
+  nombreApellido?: string;
+  situaciones?: BcraSituacion[];
+  tieneSituacion1?: boolean;
+  cantidadSituacionesTotal?: number;
+  cantidadIrregulares?: number;
+  mayorSituacion?: number | null;
+  message?: string;
+};
+
+const formatBcraAmount = (amount: number): string => `$${Math.round(amount)}`;
+
+const buildBcraDetalle = (situaciones: BcraSituacion[]): string =>
+  situaciones.map((item) => `${item.entidad}: Sit. ${item.situacion} - ${formatBcraAmount(item.monto)}`).join(" | ");
+
+export const enrichLeadWithBcra = async (lead: LeadData): Promise<LeadData> => {
+  try {
+    const response = await fetch("/api/bcra", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cuil: lead.cuil }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) {
+      return buildLeadData({ ...lead, bcraEstadoConsulta: "No disponible", bcraDetalle: "No se pudo consultar BCRA." });
+    }
+
+    const data = (await response.json()) as BcraApiResponse;
+    if (!data.success) {
+      return buildLeadData({
+        ...lead,
+        bcraEstadoConsulta: "No disponible",
+        bcraDetalle: data.message ?? "No se pudo consultar BCRA.",
+      });
+    }
+
+    const situaciones = data.situaciones ?? [];
+    return buildLeadData({
+      ...lead,
+      bcraEstadoConsulta: "Consultado",
+      bcraNombre: data.nombreApellido ?? "",
+      bcraTieneSituacion1: String(Boolean(data.tieneSituacion1)),
+      bcraCantidadTotal: String(data.cantidadSituacionesTotal ?? 0),
+      bcraCantidadIrregulares: String(data.cantidadIrregulares ?? 0),
+      bcraMayorSituacion: data.mayorSituacion == null ? "" : String(data.mayorSituacion),
+      bcraDetalle: buildBcraDetalle(situaciones),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "No se pudo consultar BCRA.";
+    return buildLeadData({ ...lead, bcraEstadoConsulta: "No disponible", bcraDetalle: message });
   }
 };


### PR DESCRIPTION
### Motivation
- Ejecutar la consulta BCRA solo al final del flujo de María (cuando ya existe nombre, DNI, sexo, CUIL, actividad, banco y contacto) y guardar su resultado junto con el lead en Google Sheets sin interrumpir el chat si la consulta falla.

### Description
- Se agregó `enrichLeadWithBcra` en `src/components/chat/mariaCredizzaChat.utils.ts` para llamar a `POST /api/bcra` con timeout (8s), normalizar la respuesta y generar un resumen legible (`bcraDetalle`), con manejo tolerante a errores que deja `bcraEstadoConsulta: "No disponible"` en fallos.
- Se extendió el tipo `LeadData` y `buildLeadData` con los campos BCRA requeridos (`bcraEstadoConsulta`, `bcraNombre`, `bcraTieneSituacion1`, `bcraCantidadTotal`, `bcraCantidadIrregulares`, `bcraMayorSituacion`, `bcraDetalle`) para mantener TypeScript estricto y tipado.
- Se integró la llamada a `enrichLeadWithBcra` justo antes de persistir el lead en el flujo (tanto al derivar a WhatsApp como al guardar contacto alternativo) en `src/components/chat/MariaCredizzaChat.tsx` y se persiste el lead enriquecido mediante `saveLeadMock`.
- Se actualizó el endpoint `POST /api/leads` en `src/app/api/leads/route.ts` para aceptar y adjuntar los campos BCRA al registro en Google Sheets y apuntar al rango de la hoja `Leads Credizza - Precalificador Web` (`A:R`).

### Testing
- Ejecuté `npm run lint` y terminó sin errores de build; quedaron warnings preexistentes en `src/app/not-found.tsx` que no afectan estos cambios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03eaa7e8b88321a9f2e3df2cbdc7c6)